### PR TITLE
Add My Orders screen and navigation

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -3,6 +3,7 @@ import 'package:luxnewyork_flutter_app/screens/profile_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/wishlist_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/cart_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/home_screen.dart';
+import 'package:luxnewyork_flutter_app/screens/my_orders_screen.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -20,6 +21,7 @@ class _MainScreenState extends State<MainScreen> {
     const HomeScreen(),
     const WishlistScreen(),
     const CartScreen(),
+    const MyOrdersScreen(),
   ];
 
   // Handles BottomNavigationBar item selection
@@ -73,7 +75,7 @@ class _MainScreenState extends State<MainScreen> {
           BottomNavigationBarItem(
               icon: Icon(Icons.shopping_bag), label: "Cart"),
           BottomNavigationBarItem(
-              icon: Icon(Icons.local_shipping), label: "My Orders"),
+              icon: Icon(Icons.receipt_long), label: "My Orders"),
         ],
       ),
     );

--- a/lib/screens/my_orders_screen.dart
+++ b/lib/screens/my_orders_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:luxnewyork_flutter_app/models/product_data.dart';
+
+class Order {
+  final Product product;
+  final String orderDate;
+  final String status;
+
+  Order({required this.product, required this.orderDate, required this.status});
+}
+
+final List<Order> orders = [
+  Order(product: products[0], orderDate: '2025-05-20', status: 'Delivered'),
+  Order(product: products[3], orderDate: '2025-05-25', status: 'Processing'),
+  Order(product: products[6], orderDate: '2025-06-01', status: 'Shipped'),
+];
+
+class MyOrdersScreen extends StatelessWidget {
+  const MyOrdersScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('My Orders', style: textTheme.titleLarge),
+            const SizedBox(height: 20),
+            Expanded(
+              child: orders.isNotEmpty
+                  ? ListView.builder(
+                      physics: const BouncingScrollPhysics(),
+                      itemCount: orders.length,
+                      itemBuilder: (context, index) {
+                        final order = orders[index];
+                        return Card(
+                          margin: const EdgeInsets.symmetric(vertical: 8),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10)),
+                          child: ListTile(
+                            leading: Image.asset(
+                              order.product.imagePath,
+                              width: 50,
+                              height: 50,
+                              fit: BoxFit.cover,
+                            ),
+                            title: Text(order.product.name,
+                                style: textTheme.bodyLarge),
+                            subtitle: Text(
+                              'Date: ${order.orderDate}\nStatus: ${order.status}',
+                              style: textTheme.bodyMedium,
+                            ),
+                            isThreeLine: true,
+                          ),
+                        );
+                      },
+                    )
+                  : Center(
+                      child: Text('No orders yet',
+                          style: textTheme.bodyMedium),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MyOrdersScreen` with sample order list
- import and display `MyOrdersScreen` in the main navigation
- update navigation bar icon for orders

## Testing
- `flutter format lib/screens/my_orders_screen.dart lib/screens/main_screen.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684019a14f0c83329b6bb660d597863a