### PR TITLE
Fix landscape grid columns

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -89,12 +89,18 @@ class HomeScreen extends StatelessWidget {
 
   // Product Grid - //ANCHOR - Use of scrolable list
   Widget _buildProductGrid(BuildContext context) {
+    // Determine current orientation
+    Orientation orientation = MediaQuery.of(context).orientation;
+
+    // Set crossAxisCount based on orientation
+    int crossAxisCount = orientation == Orientation.portrait ? 2 : 4;
+
     return GridView.builder(
       shrinkWrap: true,
-      physics: const BouncingScrollPhysics(), // Adds smooth scrolling effect
+      physics: const BouncingScrollPhysics(),
       itemCount: products.length,
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 2,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
         crossAxisSpacing: 10,
         mainAxisSpacing: 10,
         childAspectRatio: 0.6,


### PR DESCRIPTION
## Summary
- adjust `HomeScreen` grid to show 4 items when in landscape

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e3f00fc83328f627daf086471de