### PR TITLE
Add theme preferences and about page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,6 +53,7 @@ import 'theme/theme.dart';
 // Providers
 import 'providers/cart_provider.dart';
 import 'providers/wishlist_provider.dart';
+import 'providers/theme_provider.dart';
 
 void main() {
   runApp(
@@ -60,6 +61,7 @@ void main() {
       providers: [
         ChangeNotifierProvider(create: (_) => CartProvider()),
         ChangeNotifierProvider(create: (_) => WishlistProvider()),
+        ChangeNotifierProvider(create: (_) => ThemeProvider()),
       ],
       child: const MyApp(),
     ),
@@ -71,11 +73,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context);
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: lightTheme,
       darkTheme: darkTheme,
-      themeMode: ThemeMode.system,
+      themeMode: themeProvider.themeMode,
       home: const SplashScreen(), // The splash screen can decide login vs home
     );
   }

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeMode _themeMode = ThemeMode.system;
+
+  ThemeMode get themeMode => _themeMode;
+
+  ThemeProvider() {
+    _loadThemeMode();
+  }
+
+  Future<void> _loadThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final mode = prefs.getString('theme_mode');
+    switch (mode) {
+      case 'light':
+        _themeMode = ThemeMode.light;
+        break;
+      case 'dark':
+        _themeMode = ThemeMode.dark;
+        break;
+      default:
+        _themeMode = ThemeMode.system;
+    }
+    notifyListeners();
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    _themeMode = mode;
+    final prefs = await SharedPreferences.getInstance();
+    final value = mode == ThemeMode.light
+        ? 'light'
+        : mode == ThemeMode.dark
+            ? 'dark'
+            : 'system';
+    await prefs.setString('theme_mode', value);
+    notifyListeners();
+  }
+}

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Scaffold(
+      appBar: AppBar(title: Text('About', style: textTheme.headlineSmall)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Text(
+          'LUXNEWYORK is a conceptual luxury eyewear company built for learning.',
+          style: textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/preferences_screen.dart
+++ b/lib/screens/preferences_screen.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/theme_provider.dart';
+
+class PreferencesScreen extends StatelessWidget {
+  const PreferencesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final themeProvider = context.watch<ThemeProvider>();
+    return Scaffold(
+      appBar: AppBar(title: Text('Preferences', style: textTheme.headlineSmall)),
+      body: Column(
+        children: [
+          RadioListTile<ThemeMode>(
+            title: const Text('Light Mode'),
+            value: ThemeMode.light,
+            groupValue: themeProvider.themeMode,
+            onChanged: (mode) {
+              if (mode != null) {
+                context.read<ThemeProvider>().setThemeMode(mode);
+              }
+            },
+          ),
+          RadioListTile<ThemeMode>(
+            title: const Text('Dark Mode'),
+            value: ThemeMode.dark,
+            groupValue: themeProvider.themeMode,
+            onChanged: (mode) {
+              if (mode != null) {
+                context.read<ThemeProvider>().setThemeMode(mode);
+              }
+            },
+          ),
+          RadioListTile<ThemeMode>(
+            title: const Text('System'),
+            value: ThemeMode.system,
+            groupValue: themeProvider.themeMode,
+            onChanged: (mode) {
+              if (mode != null) {
+                context.read<ThemeProvider>().setThemeMode(mode);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -133,6 +133,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:luxnewyork_flutter_app/screens/login_screen.dart';
+import 'package:luxnewyork_flutter_app/screens/preferences_screen.dart';
+import 'package:luxnewyork_flutter_app/screens/about_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class ProfileScreen extends StatelessWidget {
@@ -250,9 +252,22 @@ class _ProfileMenu extends StatelessWidget {
 
     return Column(
       children: [
-        _buildMenuItem(Icons.shopping_bag, "My Orders", textTheme, () {}),
-        _buildMenuItem(Icons.language, "Preferences", textTheme, () {}),
-        _buildMenuItem(Icons.credit_card, "Payment Methods", textTheme, () {}),
+        _buildMenuItem(Icons.language, "Preferences", textTheme, () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => const PreferencesScreen(),
+            ),
+          );
+        }),
+        _buildMenuItem(Icons.info, "About", textTheme, () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => const AboutScreen(),
+            ),
+          );
+        }),
         _buildMenuItem(Icons.settings, "Account Settings", textTheme, () {}),
       ],
     );

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,22 +9,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:luxnewyork_flutter_app/main.dart';
+import 'package:provider/provider.dart';
+import 'package:luxnewyork_flutter_app/providers/cart_provider.dart';
+import 'package:luxnewyork_flutter_app/providers/wishlist_provider.dart';
+import 'package:luxnewyork_flutter_app/providers/theme_provider.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('App builds', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => CartProvider()),
+          ChangeNotifierProvider(create: (_) => WishlistProvider()),
+          ChangeNotifierProvider(create: (_) => ThemeProvider()),
+        ],
+        child: const MyApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add ThemeProvider for managing ThemeMode
- add PreferencesScreen with dark/light/system selector
- create AboutScreen
- update profile menu to remove orders/payments and add about/preferences
- use ThemeProvider in main app
- update tests to include providers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843417ebf908332a4653e3a98ba357c