### PR TITLE
Add connectivity overlay

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,8 @@ import 'theme/theme.dart';
 import 'providers/cart_provider.dart';
 import 'providers/wishlist_provider.dart';
 import 'providers/theme_provider.dart';
+import 'providers/connectivity_provider.dart';
+import 'widgets/no_internet_overlay.dart';
 
 void main() {
   runApp(
@@ -62,6 +64,7 @@ void main() {
         ChangeNotifierProvider(create: (_) => CartProvider()),
         ChangeNotifierProvider(create: (_) => WishlistProvider()),
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
+        ChangeNotifierProvider(create: (_) => ConnectivityProvider()),
       ],
       child: const MyApp(),
     ),
@@ -79,7 +82,9 @@ class MyApp extends StatelessWidget {
       theme: lightTheme,
       darkTheme: darkTheme,
       themeMode: themeProvider.themeMode,
-      home: const SplashScreen(), // The splash screen can decide login vs home
+      home: const SplashScreen(),
+      builder: (context, child) =>
+          NoInternetOverlay(child: child ?? const SizedBox()),
     );
   }
 }

--- a/lib/providers/connectivity_provider.dart
+++ b/lib/providers/connectivity_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class ConnectivityProvider extends ChangeNotifier {
+  final Connectivity _connectivity = Connectivity();
+  bool _isOnline = true;
+
+  bool get isOnline => _isOnline;
+
+  ConnectivityProvider() {
+    _init();
+  }
+
+  Future<void> _init() async {
+    _isOnline = await _checkConnection();
+    notifyListeners();
+    _connectivity.onConnectivityChanged.listen((result) async {
+      final wasOnline = _isOnline;
+      _isOnline = result != ConnectivityResult.none;
+      if (wasOnline != _isOnline) {
+        notifyListeners();
+      }
+    });
+  }
+
+  Future<bool> _checkConnection() async {
+    final result = await _connectivity.checkConnectivity();
+    return result != ConnectivityResult.none;
+  }
+
+  Future<void> retry() async {
+    _isOnline = await _checkConnection();
+    notifyListeners();
+  }
+}

--- a/lib/widgets/no_internet_overlay.dart
+++ b/lib/widgets/no_internet_overlay.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/connectivity_provider.dart';
+
+class NoInternetOverlay extends StatelessWidget {
+  final Widget child;
+  const NoInternetOverlay({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ConnectivityProvider>(
+      builder: (context, connectivity, _) {
+        return Stack(
+          children: [
+            child,
+            if (!connectivity.isOnline)
+              Positioned.fill(
+                child: Container(
+                  color: Colors.black45,
+                  alignment: Alignment.center,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.wifi_off,
+                          size: 80, color: Theme.of(context).colorScheme.onBackground),
+                      const SizedBox(height: 16),
+                      Text('No Internet Connection',
+                          style: Theme.of(context).textTheme.bodyLarge),
+                      const SizedBox(height: 24),
+                      ElevatedButton(
+                        onPressed: connectivity.retry,
+                        child: const Text('Retry'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   http: ^1.4.0
   shared_preferences: ^2.5.3
   provider: ^6.1.5
+  connectivity_plus: ^6.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- detect network connectivity with a new provider
- show a reusable No Internet overlay with a retry button
- wrap the whole app in the overlay
- add `connectivity_plus` to dependencies