### PR TITLE
Add camera-based user profile photo

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -250,6 +250,7 @@ class _LoginScreenState extends State<LoginScreen> {
         // Store token in shared preferences
         final prefs = await SharedPreferences.getInstance();
         await prefs.setString('auth_token', token);
+        await prefs.setString('user_email', _emailController.text.trim());
 
         // Navigate to main screen
         Navigator.pushReplacement(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   shared_preferences: ^2.5.3
   provider: ^6.1.5
   connectivity_plus: ^6.0.3
+  image_picker: ^1.0.7
+  path_provider: ^2.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `image_picker` and `path_provider` dependencies
- save user email on login
- persist per-user profile photo and allow camera capture
- remove stored data on logout
- fix applying captured photo as profile image

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684386397c2c8332a78c931e17918f37