### PR TITLE
Fix store proximity notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Permissions required for location-based store alerts and notifications -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="luxnewyork_flutter_app"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,11 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>This app uses your location to find nearby stores.</string>
+        <key>NSUserNotificationUsageDescription</key>
+        <string>Notifications alert you about nearby stores.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- request user permissions for notifications and location
- declare required permissions in Android and iOS config
- add location permission checks when detecting nearby stores