### PR TITLE
Load about content from remote source

### DIFF
--- a/lib/models/about_item.dart
+++ b/lib/models/about_item.dart
@@ -1,0 +1,13 @@
+class AboutItem {
+  final String title;
+  final String description;
+
+  AboutItem({required this.title, required this.description});
+
+  factory AboutItem.fromJson(Map<String, dynamic> json) {
+    return AboutItem(
+      title: json['title'] as String,
+      description: json['description'] as String,
+    );
+  }
+}

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,30 +1,12 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
-
-class AboutItem {
-  final String title;
-  final String description;
-
-  AboutItem({required this.title, required this.description});
-
-  factory AboutItem.fromJson(Map<String, dynamic> json) {
-    return AboutItem(
-      title: json['title'] as String,
-      description: json['description'] as String,
-    );
-  }
-}
+import '../models/about_item.dart';
+import '../services/external_json_service.dart';
 
 class AboutScreen extends StatelessWidget {
   const AboutScreen({super.key});
 
   Future<List<AboutItem>> _loadItems() async {
-    final data = await rootBundle.loadString('assets/data/about_items.json');
-    final List<dynamic> jsonList = jsonDecode(data) as List<dynamic>;
-    return jsonList
-        .map((item) => AboutItem.fromJson(item as Map<String, dynamic>))
-        .toList();
+    return ExternalJsonService.fetchAboutItems();
   }
 
   @override

--- a/lib/services/external_json_service.dart
+++ b/lib/services/external_json_service.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../models/about_item.dart';
+
+class ExternalJsonService {
+  static const String _remoteUrl = 'https://example.com/about_items.json';
+
+  static Future<List<AboutItem>> fetchAboutItems() async {
+    try {
+      final response = await http.get(Uri.parse(_remoteUrl));
+      if (response.statusCode == 200) {
+        final List<dynamic> jsonList = jsonDecode(response.body) as List<dynamic>;
+        return jsonList
+            .map((item) => AboutItem.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+    } catch (_) {
+      // ignore and fall back to asset
+    }
+
+    final data = await rootBundle.loadString('assets/data/about_items.json');
+    final List<dynamic> jsonList = jsonDecode(data) as List<dynamic>;
+    return jsonList
+        .map((item) => AboutItem.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+}


### PR DESCRIPTION
## Summary
- extract `AboutItem` model to share between widgets and services
- add `ExternalJsonService` with online/offline fallback
- fetch about items via the new service