### PR TITLE
Display user name on profile

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -55,11 +55,22 @@ class _LoginScreenState extends State<LoginScreen> {
       if (response.statusCode == 200) {
         final responseData = json.decode(response.body);
         final token = responseData['token'];
+        String? name;
+        String? emailFromServer;
+        if (responseData['user'] != null) {
+          final user = responseData['user'];
+          name = user['name'];
+          emailFromServer = user['email'];
+        }
 
-        // Store token in shared preferences
+        // Store token and user data in shared preferences
         final prefs = await SharedPreferences.getInstance();
         await prefs.setString('auth_token', token);
-        await prefs.setString('user_email', _emailController.text.trim());
+        await prefs.setString('user_email',
+            emailFromServer ?? _emailController.text.trim());
+        if (name != null) {
+          await prefs.setString('user_name', name);
+        }
 
         // Navigate to main screen
         Navigator.pushReplacement(

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -36,6 +36,7 @@ class ProfileScreen extends StatelessWidget {
               final prefs = await SharedPreferences.getInstance();
               final email = prefs.getString('user_email');
               await prefs.remove('auth_token');
+              await prefs.remove('user_name');
               if (email != null) {
                 await prefs.remove('user_email');
                 await prefs.remove('profile_photo_$email');
@@ -103,6 +104,7 @@ class _UserProfileSection extends StatefulWidget {
 class _UserProfileSectionState extends State<_UserProfileSection> {
   File? _profileImage;
   String? _email;
+  String? _name;
 
   @override
   void initState() {
@@ -113,12 +115,14 @@ class _UserProfileSectionState extends State<_UserProfileSection> {
   Future<void> _loadProfile() async {
     final prefs = await SharedPreferences.getInstance();
     final email = prefs.getString('user_email');
+    final name = prefs.getString('user_name');
     String? imagePath;
     if (email != null) {
       imagePath = prefs.getString('profile_photo_$email');
     }
     setState(() {
       _email = email;
+      _name = name;
       if (imagePath != null && File(imagePath).existsSync()) {
         _profileImage = File(imagePath);
       }
@@ -165,6 +169,8 @@ class _UserProfileSectionState extends State<_UserProfileSection> {
           ),
         ),
         const SizedBox(height: 10),
+        if (_name != null)
+          Text(_name!, style: textTheme.titleMedium),
         if (_email != null)
           Text(_email!,
               style:


### PR DESCRIPTION
## Summary
- show name from login API and store it in local prefs
- display stored name along with email in the profile screen
- clear stored name on logout

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443eeaa99483328e26cafad1bb8f40