### PR TITLE
Add skeleton loading widgets

### DIFF
--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/about_item.dart';
 import '../services/external_json_service.dart';
+import '../widgets/list_tile_skeleton.dart';
 
 class AboutScreen extends StatelessWidget {
   const AboutScreen({super.key});
@@ -18,7 +19,10 @@ class AboutScreen extends StatelessWidget {
         future: _loadItems(),
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
+            return ListView.builder(
+              itemCount: 5,
+              itemBuilder: (_, __) => const ListTileSkeleton(),
+            );
           }
           if (snapshot.hasError) {
             return const Center(child: Text('Error: \${snapshot.error}'));

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/cart_provider.dart';
+import '../widgets/list_tile_skeleton.dart';
 
 class CartScreen extends StatefulWidget {
   const CartScreen({super.key});
@@ -47,14 +48,10 @@ class _CartScreenState extends State<CartScreen> {
 
     Widget body;
     if (_isLoading) {
-      body = ListView(
+      body = ListView.builder(
         physics: const AlwaysScrollableScrollPhysics(),
-        children: const [
-          SizedBox(
-            height: 300,
-            child: Center(child: CircularProgressIndicator()),
-          )
-        ],
+        itemCount: 3,
+        itemBuilder: (_, __) => const ListTileSkeleton(),
       );
     } else if (_error != null) {
       body = ListView(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -136,6 +136,8 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:luxnewyork_flutter_app/widgets/category_filter.dart';
 import 'package:luxnewyork_flutter_app/widgets/product_card.dart';
 import 'package:luxnewyork_flutter_app/widgets/search_bar.dart';
+import 'package:luxnewyork_flutter_app/widgets/product_card_skeleton.dart';
+import 'package:luxnewyork_flutter_app/widgets/category_filter_skeleton.dart';
 
 // ANCHOR models
 import 'package:luxnewyork_flutter_app/models/product.dart';
@@ -276,9 +278,17 @@ class _HomeScreenState extends State<HomeScreen> {
       future: _productFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Padding(
-            padding: EdgeInsets.symmetric(vertical: 60),
-            child: Center(child: CircularProgressIndicator()),
+          return GridView.builder(
+            shrinkWrap: true,
+            physics: const BouncingScrollPhysics(),
+            itemCount: 6,
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              crossAxisSpacing: 10,
+              mainAxisSpacing: 10,
+              childAspectRatio: 0.6,
+            ),
+            itemBuilder: (_, __) => const ProductCardSkeleton(),
           );
         } else if (snapshot.hasError) {
           return Padding(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -5,6 +5,7 @@ import 'package:luxnewyork_flutter_app/screens/main_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/signup_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/forgot_password_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -233,7 +234,7 @@ class _LoginScreenState extends State<LoginScreen> {
           textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
         ),
         child: _isLoading
-            ? const CircularProgressIndicator(color: Colors.white)
+            ? const Skeleton(height: 20, width: 20)
             : const Text("Login"),
       ),
     );

--- a/lib/screens/product_detail_screen.dart
+++ b/lib/screens/product_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:luxnewyork_flutter_app/models/product.dart';
 import 'package:luxnewyork_flutter_app/providers/cart_provider.dart';
+import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   final Product product;
@@ -57,7 +58,7 @@ class ProductDetailScreen extends StatelessWidget {
               if (loadingProgress == null) return child;
               return const SizedBox(
                 height: 300,
-                child: Center(child: CircularProgressIndicator()),
+                child: Skeleton(height: 300),
               );
             },
           ),

--- a/lib/screens/wishlist_screen.dart
+++ b/lib/screens/wishlist_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:luxnewyork_flutter_app/providers/wishlist_provider.dart';
 import 'package:luxnewyork_flutter_app/widgets/product_card.dart';
+import 'package:luxnewyork_flutter_app/widgets/product_card_skeleton.dart';
 
 class WishlistScreen extends StatefulWidget {
   const WishlistScreen({super.key});
@@ -50,14 +51,18 @@ class _WishlistScreenState extends State<WishlistScreen> {
 
     Widget body;
     if (_isLoading) {
-      body = ListView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        children: const [
-          SizedBox(
-            height: 300,
-            child: Center(child: CircularProgressIndicator()),
-          )
-        ],
+      body = Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: GridView.builder(
+          itemCount: 6,
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            crossAxisSpacing: 10,
+            mainAxisSpacing: 10,
+            childAspectRatio: 0.6,
+          ),
+          itemBuilder: (_, __) => const ProductCardSkeleton(),
+        ),
       );
     } else if (_error != null) {
       body = ListView(

--- a/lib/widgets/category_filter.dart
+++ b/lib/widgets/category_filter.dart
@@ -68,6 +68,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/category.dart';
 import '../services/api_service.dart';
 import '../services/storage_service.dart';
+import 'category_filter_skeleton.dart';
 
 class CategoryFilter extends StatefulWidget {
   final Function(int? categoryId)? onCategorySelected;
@@ -123,7 +124,7 @@ class _CategoryFilterState extends State<CategoryFilter> {
     return SizedBox(
       height: 50,
       child: _categories.isEmpty
-          ? const Center(child: CircularProgressIndicator())
+          ? const CategoryFilterSkeleton()
           : ListView.builder(
               scrollDirection: Axis.horizontal,
               physics: const BouncingScrollPhysics(),

--- a/lib/widgets/category_filter_skeleton.dart
+++ b/lib/widgets/category_filter_skeleton.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'skeleton.dart';
+
+class CategoryFilterSkeleton extends StatelessWidget {
+  const CategoryFilterSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 50,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: 5,
+        itemBuilder: (context, index) => Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 12),
+          child: Skeleton(
+            width: 70,
+            height: 20,
+            borderRadius: BorderRadius.circular(20),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/list_tile_skeleton.dart
+++ b/lib/widgets/list_tile_skeleton.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'skeleton.dart';
+
+class ListTileSkeleton extends StatelessWidget {
+  const ListTileSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          Skeleton(width: 50, height: 50, borderRadius: BorderRadius.circular(8)),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                Skeleton(height: 16),
+                SizedBox(height: 8),
+                Skeleton(height: 14, width: 80),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/product_card_skeleton.dart
+++ b/lib/widgets/product_card_skeleton.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'skeleton.dart';
+
+class ProductCardSkeleton extends StatelessWidget {
+  const ProductCardSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Skeleton(
+              height: double.infinity,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(10)),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                Skeleton(height: 16),
+                SizedBox(height: 4),
+                Skeleton(height: 14, width: 80),
+                SizedBox(height: 4),
+                Skeleton(height: 16, width: 60),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/skeleton.dart
+++ b/lib/widgets/skeleton.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class Skeleton extends StatelessWidget {
+  final double width;
+  final double height;
+  final BorderRadius borderRadius;
+
+  const Skeleton({
+    super.key,
+    this.width = double.infinity,
+    required this.height,
+    this.borderRadius = BorderRadius.zero,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: Colors.grey.shade300,
+      highlightColor: Colors.grey.shade100,
+      child: Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          color: Colors.grey.shade300,
+          borderRadius: borderRadius,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   geolocator: 14.0.1
   flutter_local_notifications: ^19.2.1
   permission_handler: ^11.0.1
+  shimmer: ^3.0.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add shimmer dependency for skeleton effects
- implement generic Skeleton widget and specialized skeleton widgets
- display skeletons in category filter, product grid, list views, and buttons
- replace CircularProgressIndicator usage in multiple screens

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68444547563c833291aac5e7a60576e3