### PR TITLE
Add product lazy loading with Provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'theme/theme.dart';
 import 'providers/cart_provider.dart';
 import 'providers/wishlist_provider.dart';
 import 'providers/theme_provider.dart';
+import 'providers/product_provider.dart';
 
 import 'services/store_proximity_service.dart';
 
@@ -83,6 +84,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => CartProvider()),
         ChangeNotifierProvider(create: (_) => WishlistProvider()),
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
+        ChangeNotifierProvider(create: (_) => ProductProvider()),
       ],
       child: const MyApp(),
     ),

--- a/lib/providers/product_provider.dart
+++ b/lib/providers/product_provider.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/product.dart';
+import '../services/api_service.dart';
+import '../services/storage_service.dart';
+
+class ProductProvider extends ChangeNotifier {
+  final int _perPage = 10;
+  List<Product> _products = [];
+  int _page = 1;
+  bool _isLoading = false;
+  bool _isLoadingMore = false;
+  bool _hasMore = true;
+  int? _categoryId;
+  String _searchQuery = '';
+
+  List<Product> get products => _products;
+  bool get isLoading => _isLoading;
+  bool get isLoadingMore => _isLoadingMore;
+  bool get hasMore => _hasMore;
+
+  Future<void> fetchProducts({int? categoryId, String search = ''}) async {
+    _page = 1;
+    _hasMore = true;
+    _products = [];
+    _categoryId = categoryId;
+    _searchQuery = search;
+    _isLoading = true;
+    notifyListeners();
+
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token') ?? '';
+
+    final connectivityResult = await Connectivity().checkConnectivity();
+    if (connectivityResult == ConnectivityResult.none) {
+      _products = await StorageService.loadProducts();
+      _isLoading = false;
+      _hasMore = false;
+      notifyListeners();
+      return;
+    }
+
+    try {
+      final fetched = await ApiService.fetchProducts(
+        token,
+        categoryId: categoryId,
+        search: search,
+        page: _page,
+        limit: _perPage,
+      );
+      _products = fetched;
+      if (fetched.length < _perPage) _hasMore = false;
+      await StorageService.saveProducts(_products);
+    } catch (_) {
+      final cached = await StorageService.loadProducts();
+      _products = cached;
+      _hasMore = false;
+    }
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<void> loadMore() async {
+    if (!_hasMore || _isLoadingMore) return;
+    _isLoadingMore = true;
+    notifyListeners();
+    _page++;
+
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token') ?? '';
+    try {
+      final fetched = await ApiService.fetchProducts(
+        token,
+        categoryId: _categoryId,
+        search: _searchQuery,
+        page: _page,
+        limit: _perPage,
+      );
+      _products.addAll(fetched);
+      if (fetched.length < _perPage) _hasMore = false;
+    } catch (_) {
+      _hasMore = false;
+    }
+    _isLoadingMore = false;
+    notifyListeners();
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -11,12 +11,13 @@ class ApiService {
     String token, {
     int? categoryId,
     String? search,
+    int page = 1,
+    int limit = 10,
   }) async {
-    String query = '';
-    if (categoryId != null) query += 'category_id=$categoryId';
+    String query = 'page=$page&limit=$limit';
+    if (categoryId != null) query += '&category_id=$categoryId';
     if (search != null && search.isNotEmpty) {
-      if (query.isNotEmpty) query += '&';
-      query += 'search=$search';
+      query += '&search=$search';
     }
 
     final uri =


### PR DESCRIPTION
## Summary
- implement `ProductProvider` for paginated API access
- extend `ApiService.fetchProducts` with pagination parameters
- load products via provider in `HomeScreen` with scroll-based lazy loading
- register `ProductProvider` in `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444ce1fc24833296cd166bfb46919a