### PR TITLE
Add cached_network_image and use for all network images

### DIFF
--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/cart_provider.dart';
 import '../widgets/list_tile_skeleton.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../widgets/skeleton.dart';
 
 class CartScreen extends StatefulWidget {
   const CartScreen({super.key});
@@ -82,14 +84,25 @@ class _CartScreenState extends State<CartScreen> {
           return Card(
             margin: const EdgeInsets.symmetric(vertical: 8),
             child: ListTile(
-              leading: Image(
-                image: product.imagePath.startsWith('http')
-                    ? NetworkImage(product.imagePath)
-                    : AssetImage(product.imagePath) as ImageProvider,
-                width: 50,
-                height: 50,
-                fit: BoxFit.cover,
-              ),
+              leading: product.imagePath.startsWith('http')
+                  ? CachedNetworkImage(
+                      imageUrl: product.imagePath,
+                      width: 50,
+                      height: 50,
+                      fit: BoxFit.cover,
+                      placeholder: (context, url) => Skeleton(
+                          width: 50,
+                          height: 50,
+                          borderRadius: BorderRadius.circular(8)),
+                      errorWidget: (_, __, ___) =>
+                          const Icon(Icons.broken_image),
+                    )
+                  : Image.asset(
+                      product.imagePath,
+                      width: 50,
+                      height: 50,
+                      fit: BoxFit.cover,
+                    ),
               title: Text(product.name),
               subtitle: Text(product.price),
               trailing: IconButton(

--- a/lib/screens/product_detail_screen.dart
+++ b/lib/screens/product_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:luxnewyork_flutter_app/models/product.dart';
 import 'package:luxnewyork_flutter_app/providers/cart_provider.dart';
 import 'package:luxnewyork_flutter_app/providers/connectivity_provider.dart';
 import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   final Product product;
@@ -48,20 +49,17 @@ class ProductDetailScreen extends StatelessWidget {
       children: [
         ClipRRect(
           borderRadius: BorderRadius.circular(10),
-          child: Image.network(
-            product.imagePath,
+          child: CachedNetworkImage(
+            imageUrl: product.imagePath,
             fit: BoxFit.cover,
             width: double.infinity,
             height: 300,
-            errorBuilder: (_, __, ___) =>
+            errorWidget: (_, __, ___) =>
                 const Icon(Icons.broken_image, size: 100),
-            loadingBuilder: (context, child, loadingProgress) {
-              if (loadingProgress == null) return child;
-              return const SizedBox(
-                height: 300,
-                child: Skeleton(height: 300),
-              );
-            },
+            placeholder: (context, url) => const SizedBox(
+              height: 300,
+              child: Skeleton(height: 300),
+            ),
           ),
         ),
         if (product.stock == 0)

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -4,6 +4,8 @@ import 'package:luxnewyork_flutter_app/models/product.dart';
 import 'package:luxnewyork_flutter_app/providers/wishlist_provider.dart';
 import 'package:luxnewyork_flutter_app/providers/connectivity_provider.dart';
 import 'package:luxnewyork_flutter_app/screens/product_detail_screen.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'skeleton.dart';
 
 class ProductCard extends StatelessWidget {
   final Product product;
@@ -56,13 +58,21 @@ class ProductCard extends StatelessWidget {
               child: ClipRRect(
                 borderRadius:
                     const BorderRadius.vertical(top: Radius.circular(10)),
-                child: Image(
-                  image: product.imagePath.startsWith('http')
-                      ? NetworkImage(product.imagePath)
-                      : AssetImage(product.imagePath) as ImageProvider,
-                  fit: BoxFit.cover,
-                  width: double.infinity,
-                ),
+                child: product.imagePath.startsWith('http')
+                    ? CachedNetworkImage(
+                        imageUrl: product.imagePath,
+                        fit: BoxFit.cover,
+                        width: double.infinity,
+                        placeholder: (context, url) =>
+                            const Skeleton(height: double.infinity),
+                        errorWidget: (_, __, ___) =>
+                            const Icon(Icons.broken_image),
+                      )
+                    : Image.asset(
+                        product.imagePath,
+                        fit: BoxFit.cover,
+                        width: double.infinity,
+                      ),
               ),
             ),
             const SizedBox(height: 8),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   flutter_local_notifications: ^19.2.1
   permission_handler: ^11.0.1
   shimmer: ^3.0.0
+  cached_network_image: 3.4.1
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `cached_network_image` 3.4.1 to dependencies
- replace `Image.network`/`NetworkImage` usages with `CachedNetworkImage`
- show skeleton placeholders while images load

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844607eacec8332a1e24683d44de8e9