### PR TITLE
Improve wishlist and cart connection error handling

### DIFF
--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -4,6 +4,7 @@ import '../providers/cart_provider.dart';
 import '../widgets/list_tile_skeleton.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../widgets/skeleton.dart';
+import '../widgets/connection_error_widget.dart';
 
 class CartScreen extends StatefulWidget {
   const CartScreen({super.key});
@@ -35,7 +36,7 @@ class _CartScreenState extends State<CartScreen> {
     try {
       await cart.loadCart();
     } catch (e) {
-      setState(() => _error = 'Failed to load cart');
+      setState(() => _error = 'Connection lost. Please try again.');
     } finally {
       setState(() => _isLoading = false);
     }
@@ -61,7 +62,10 @@ class _CartScreenState extends State<CartScreen> {
         children: [
           SizedBox(
             height: 300,
-            child: Center(child: Text(_error!)),
+            child: ConnectionErrorWidget(
+              message: _error!,
+              onRetry: _refreshCart,
+            ),
           )
         ],
       );

--- a/lib/screens/wishlist_screen.dart
+++ b/lib/screens/wishlist_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:luxnewyork_flutter_app/providers/wishlist_provider.dart';
 import 'package:luxnewyork_flutter_app/widgets/product_card.dart';
 import 'package:luxnewyork_flutter_app/widgets/product_card_skeleton.dart';
+import 'package:luxnewyork_flutter_app/widgets/connection_error_widget.dart';
 
 class WishlistScreen extends StatefulWidget {
   const WishlistScreen({super.key});
@@ -35,7 +36,7 @@ class _WishlistScreenState extends State<WishlistScreen> {
     try {
       await wishlist.loadWishlist();
     } catch (e) {
-      setState(() => _error = 'Failed to load wishlist');
+      setState(() => _error = 'Connection lost. Please try again.');
     } finally {
       setState(() => _isLoading = false);
     }
@@ -70,7 +71,10 @@ class _WishlistScreenState extends State<WishlistScreen> {
         children: [
           SizedBox(
             height: 300,
-            child: Center(child: Text(_error!)),
+            child: ConnectionErrorWidget(
+              message: _error!,
+              onRetry: _refreshWishlist,
+            ),
           )
         ],
       );

--- a/lib/widgets/connection_error_widget.dart
+++ b/lib/widgets/connection_error_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class ConnectionErrorWidget extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const ConnectionErrorWidget({
+    super.key,
+    required this.message,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.wifi_off,
+            size: 60,
+            color: colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ConnectionErrorWidget` with icon and retry button
- use the new widget for cart and wishlist screens
- display friendlier connection lost messages

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446f6009ec8332aac18232c03994be