### PR TITLE
Add CTA buttons for empty cart and wishlist

### DIFF
--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -6,6 +6,8 @@ import 'package:cached_network_image/cached_network_image.dart';
 import '../widgets/skeleton.dart';
 import '../widgets/connection_error_widget.dart';
 import '../providers/connectivity_provider.dart';
+import '../widgets/empty_state_widget.dart';
+import 'main_screen.dart';
 
 class CartScreen extends StatefulWidget {
   const CartScreen({super.key});
@@ -89,10 +91,20 @@ class _CartScreenState extends State<CartScreen> {
     } else if (items.isEmpty) {
       body = ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        children: const [
+        children: [
           SizedBox(
             height: 300,
-            child: Center(child: Text('Your cart is empty.')),
+            child: EmptyStateWidget(
+              message: 'Your cart is empty.',
+              actionText: 'Shop Now',
+              onAction: () {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const MainScreen()),
+                );
+              },
+              icon: Icons.shopping_bag_outlined,
+            ),
           )
         ],
       );

--- a/lib/screens/wishlist_screen.dart
+++ b/lib/screens/wishlist_screen.dart
@@ -6,6 +6,8 @@ import 'package:luxnewyork_flutter_app/widgets/product_card.dart';
 import 'package:luxnewyork_flutter_app/widgets/product_card_skeleton.dart';
 import 'package:luxnewyork_flutter_app/widgets/connection_error_widget.dart';
 import 'package:luxnewyork_flutter_app/providers/connectivity_provider.dart';
+import 'package:luxnewyork_flutter_app/widgets/empty_state_widget.dart';
+import 'main_screen.dart';
 
 class WishlistScreen extends StatefulWidget {
   const WishlistScreen({super.key});
@@ -98,14 +100,19 @@ class _WishlistScreenState extends State<WishlistScreen> {
     } else if (wishlist.isEmpty) {
       body = ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        children: const [
+        children: [
           SizedBox(
             height: 300,
-            child: Center(
-              child: Text(
-                "Your wishlist is empty.",
-                style: TextStyle(fontSize: 16),
-              ),
+            child: EmptyStateWidget(
+              message: 'Your wishlist is empty.',
+              actionText: 'Browse Products',
+              onAction: () {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const MainScreen()),
+                );
+              },
+              icon: Icons.favorite_border,
             ),
           )
         ],

--- a/lib/widgets/empty_state_widget.dart
+++ b/lib/widgets/empty_state_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class EmptyStateWidget extends StatelessWidget {
+  final String message;
+  final String actionText;
+  final VoidCallback onAction;
+  final IconData? icon;
+
+  const EmptyStateWidget({
+    super.key,
+    required this.message,
+    required this.actionText,
+    required this.onAction,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null)
+            Icon(
+              icon,
+              size: 60,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          const SizedBox(height: 16),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: onAction,
+            child: Text(actionText),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `EmptyStateWidget`
- update CartScreen empty view with Shop Now button
- update WishlistScreen empty view with Browse Products button