### PR TITLE
Update README for API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ flutter run
 flutter run -d chrome
 ```
 
+### **5. Configure API Base URL**
+
+The app communicates with a backend server using an API base URL defined in
+`lib/config.dart`. By default, it is set to:
+
+```dart
+class Config {
+  static const String apiBaseUrl = 'http://10.0.2.2:8000';
+}
+```
+
+The address `http://10.0.2.2:8000` targets a local development server that is
+reachable from Android emulators. Update `apiBaseUrl` in `lib/config.dart` when
+running on real devices or deploying to production.
+
 ---
 
 ## **Screenshots(Coming Soon)**


### PR DESCRIPTION
## Summary
- document how to change the API base URL
- note that `http://10.0.2.2:8000` is for local dev and should be updated for real devices or production

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844aa00b6008332ac9ca574288daad2