### PR TITLE
Make API base URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ flutter run
 flutter run -d chrome
 ```
 
+### **5. Configure the Backend URL**
+
+The app's API endpoint is defined in `lib/config.dart` as `apiBaseUrl`.
+Edit this constant if your backend runs on a different host or port.
+
 ---
 
 ## **Screenshots(Coming Soon)**

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,0 +1,5 @@
+/// Configuration constants for the app.
+///
+/// `apiBaseUrl` defines the root URL for all backend API calls.
+/// Update this value to point the app to a different backend.
+const String apiBaseUrl = 'http://10.0.2.2:8000';

--- a/lib/providers/cart_provider.dart
+++ b/lib/providers/cart_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/product.dart';
+import '../config.dart';
 
 class CartProvider extends ChangeNotifier {
   List<Product> _items = [];
@@ -17,7 +18,7 @@ class CartProvider extends ChangeNotifier {
 
     try {
       final response = await http.get(
-        Uri.parse('http://10.0.2.2:8000/api/cart'),
+        Uri.parse('$apiBaseUrl/api/cart'),
         headers: {'Authorization': 'Bearer $token'},
       );
 
@@ -51,7 +52,7 @@ class CartProvider extends ChangeNotifier {
     final token = prefs.getString('auth_token') ?? '';
 
     final response = await http.post(
-      Uri.parse('http://10.0.2.2:8000/api/cart'),
+      Uri.parse('$apiBaseUrl/api/cart'),
       headers: {
         'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
@@ -94,7 +95,7 @@ class CartProvider extends ChangeNotifier {
 
     if (itemId != null) {
       final response = await http.delete(
-        Uri.parse('http://10.0.2.2:8000/api/cart/$itemId'),
+        Uri.parse('$apiBaseUrl/api/cart/$itemId'),
         headers: {'Authorization': 'Bearer $token'},
       );
 

--- a/lib/providers/wishlist_provider.dart
+++ b/lib/providers/wishlist_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:luxnewyork_flutter_app/models/product.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+import '../config.dart';
 
 class WishlistProvider extends ChangeNotifier {
   List<Product> _wishlist = [];
@@ -19,7 +20,7 @@ class WishlistProvider extends ChangeNotifier {
 
     try {
       final response = await http.get(
-        Uri.parse('http://10.0.2.2:8000/api/wishlist'),
+        Uri.parse('$apiBaseUrl/api/wishlist'),
         headers: {'Authorization': 'Bearer $token'},
       );
 
@@ -58,7 +59,7 @@ class WishlistProvider extends ChangeNotifier {
       final itemId = _wishlistItemIds[product.id];
       if (itemId != null) {
         final response = await http.delete(
-          Uri.parse('http://10.0.2.2:8000/api/wishlist/$itemId'),
+          Uri.parse('$apiBaseUrl/api/wishlist/$itemId'),
           headers: {'Authorization': 'Bearer $token'},
         );
         if (response.statusCode == 200 || response.statusCode == 204) {
@@ -70,7 +71,7 @@ class WishlistProvider extends ChangeNotifier {
       }
     } else {
       final response = await http.post(
-        Uri.parse('http://10.0.2.2:8000/api/wishlist'),
+        Uri.parse('$apiBaseUrl/api/wishlist'),
         headers: {
           'Authorization': 'Bearer $token',
           'Content-Type': 'application/json',

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:luxnewyork_flutter_app/screens/signup_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/forgot_password_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
+import '../config.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -30,7 +31,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
   Future<void> _loginUser() async {
     setState(() => _isLoading = true);
-    final url = Uri.parse("http://10.0.2.2:8000/api/login");
+    final url = Uri.parse("$apiBaseUrl/api/login");
 
     try {
       final response = await http.post(

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -3,9 +3,14 @@ import 'package:http/http.dart' as http;
 import '../models/product.dart';
 import '../models/category.dart';
 import '../models/order.dart';
+import '../config.dart';
 
 class ApiService {
-  static const String baseUrl = "http://10.0.2.2:8000";
+  /// Base URL for API requests.
+  ///
+  /// This pulls the value from [apiBaseUrl] in `config.dart` so it can be
+  /// easily changed in one place.
+  static const String baseUrl = apiBaseUrl;
 
   /// NOTE fetching all the products from the api
   static Future<List<Product>> fetchProducts(


### PR DESCRIPTION
## Summary
- add `lib/config.dart` holding the `apiBaseUrl` constant
- reference `apiBaseUrl` from `ApiService`
- update cart, wishlist, and login code to build URLs using the constant
- document backend URL configuration in the README