### PR TITLE
Improve empty state UI alignment

### DIFF
--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -83,11 +83,16 @@ class _CartScreenState extends State<CartScreen> {
         itemBuilder: (_, __) => const ListTileSkeleton(),
       );
     } else if (_error != null) {
+      final emptyHeight = MediaQuery.of(context).size.height -
+          kToolbarHeight -
+          kBottomNavigationBarHeight -
+          MediaQuery.of(context).padding.top;
+
       body = ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         children: [
           SizedBox(
-            height: 300,
+            height: emptyHeight,
             child: ConnectionErrorWidget(
               message: _error!,
               onRetry: _refreshCart,
@@ -96,11 +101,16 @@ class _CartScreenState extends State<CartScreen> {
         ],
       );
     } else if (items.isEmpty) {
+      final emptyHeight = MediaQuery.of(context).size.height -
+          kToolbarHeight -
+          kBottomNavigationBarHeight -
+          MediaQuery.of(context).padding.top;
+
       body = ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         children: [
           SizedBox(
-            height: 300,
+            height: emptyHeight,
             child: EmptyStateWidget(
               message: 'Your cart is empty.',
               actionText: 'Shop Now',

--- a/lib/screens/my_orders_screen.dart
+++ b/lib/screens/my_orders_screen.dart
@@ -5,6 +5,8 @@ import 'package:provider/provider.dart';
 
 import '../providers/order_provider.dart';
 import '../widgets/list_tile_skeleton.dart';
+import '../widgets/empty_state_widget.dart';
+import 'main_screen.dart';
 
 class MyOrdersScreen extends StatefulWidget {
   const MyOrdersScreen({super.key});
@@ -79,12 +81,27 @@ class _MyOrdersScreenState extends State<MyOrdersScreen> {
           }
 
           if (provider.orders.isEmpty) {
+            final emptyHeight = MediaQuery.of(context).size.height -
+                kToolbarHeight -
+                kBottomNavigationBarHeight -
+                MediaQuery.of(context).padding.top;
+
             return ListView(
               physics: const AlwaysScrollableScrollPhysics(),
-              children: const [
+              children: [
                 SizedBox(
-                  height: 300,
-                  child: Center(child: Text('No orders found')),
+                  height: emptyHeight,
+                  child: EmptyStateWidget(
+                    message: 'No orders found.',
+                    actionText: 'Shop Now',
+                    onAction: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(builder: (_) => const MainScreen()),
+                      );
+                    },
+                    icon: Icons.receipt_long,
+                  ),
                 ),
               ],
             );

--- a/lib/screens/wishlist_screen.dart
+++ b/lib/screens/wishlist_screen.dart
@@ -98,11 +98,16 @@ class _WishlistScreenState extends State<WishlistScreen> {
         ],
       );
     } else if (wishlist.isEmpty) {
+      final emptyHeight = MediaQuery.of(context).size.height -
+          kToolbarHeight -
+          kBottomNavigationBarHeight -
+          MediaQuery.of(context).padding.top;
+
       body = ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         children: [
           SizedBox(
-            height: 300,
+            height: emptyHeight,
             child: EmptyStateWidget(
               message: 'Your wishlist is empty.',
               actionText: 'Browse Products',


### PR DESCRIPTION
## Summary
- center empty state widgets in wishlist and cart screens
- use the same empty state style for orders