### PR TITLE
Fix signup snackbar persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ import 'package:provider/provider.dart';
 
 import 'screens/splash_screen.dart';
 import 'theme/theme.dart';
+import 'utils/snackbar_service.dart';
 
 // Providers
 import 'providers/cart_provider.dart';
@@ -93,6 +94,7 @@ class MyApp extends StatelessWidget {
       theme: lightTheme,
       darkTheme: darkTheme,
       themeMode: themeProvider.themeMode,
+      scaffoldMessengerKey: rootScaffoldMessengerKey,
       home: const SplashScreen(), // The splash screen can decide login vs home
     );
   }

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:luxnewyork_flutter_app/screens/main_screen.dart';
 import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
+import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
 import '../config.dart';
 
 class SignupScreen extends StatefulWidget {
@@ -68,14 +69,14 @@ class _SignupScreenState extends State<SignupScreen> {
 
         if (!mounted) return;
 
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Registration successful')),
-        );
-
         Navigator.pushAndRemoveUntil(
           context,
           MaterialPageRoute(builder: (_) => const MainScreen()),
           (route) => false,
+        );
+
+        showAppSnackBar(
+          const SnackBar(content: Text('Registration successful')),
         );
       } else {
         final responseBody = json.decode(response.body);

--- a/lib/utils/snackbar_service.dart
+++ b/lib/utils/snackbar_service.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// Global key to access the root [ScaffoldMessengerState].
+final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+    GlobalKey<ScaffoldMessengerState>();
+
+/// Convenience method to show a [SnackBar] using the root messenger.
+void showAppSnackBar(SnackBar snackBar) {
+  rootScaffoldMessengerKey.currentState
+    ?..hideCurrentSnackBar()
+    ..showSnackBar(snackBar);
+}


### PR DESCRIPTION
## Summary
- use a global scaffold messenger key to manage SnackBars
- show signup success message after navigating to the main screen