### PR TITLE
Replace showSnackBar calls with showAppSnackBar

### DIFF
--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -11,6 +11,7 @@ import '../providers/connectivity_provider.dart';
 import '../widgets/empty_state_widget.dart';
 import 'main_screen.dart';
 import 'checkout_screen.dart';
+import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
 
 class CartScreen extends StatefulWidget {
   const CartScreen({super.key});
@@ -161,7 +162,7 @@ class _CartScreenState extends State<CartScreen> {
                   try {
                     await cartProvider.removeItem(product.id);
                   } catch (_) {
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    showAppSnackBar(
                       const SnackBar(content: Text('Failed to remove item')),
                     );
                   }

--- a/lib/screens/checkout_screen.dart
+++ b/lib/screens/checkout_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
 import '../providers/order_provider.dart';
 import '../providers/cart_provider.dart';
 
@@ -30,13 +31,13 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
     if (order != null) {
       await cartProvider.loadCart();
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
+      showAppSnackBar(
         const SnackBar(content: Text('Order placed successfully')),
       );
       Navigator.pop(context);
     } else {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
+      showAppSnackBar(
         const SnackBar(content: Text('Failed to place order')),
       );
     }

--- a/lib/screens/forgot_password_screen.dart
+++ b/lib/screens/forgot_password_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
 import 'login_screen.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
@@ -15,7 +16,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
 
   void _resetPassword() {
     if (_formKey.currentState!.validate()) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      showAppSnackBar(
         const SnackBar(content: Text('Password Reset Email Sent!')),
       );
 

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -13,6 +13,7 @@ import 'package:luxnewyork_flutter_app/providers/cart_provider.dart';
 import 'package:luxnewyork_flutter_app/providers/theme_provider.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:battery_plus/battery_plus.dart';
+import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -62,7 +63,7 @@ class _MainScreenState extends State<MainScreen> {
     );
 
     if (level < 15) {
-      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+      showAppSnackBar(snackBar);
     }
   }
 
@@ -91,7 +92,7 @@ class _MainScreenState extends State<MainScreen> {
         final message = offline ? 'You are offline' : 'Back online';
         final color = offline ? Colors.red : Colors.green;
 
-        ScaffoldMessenger.of(context).showSnackBar(
+        showAppSnackBar(
           SnackBar(
             content: Text(message),
             backgroundColor: color,

--- a/lib/screens/product_detail_screen.dart
+++ b/lib/screens/product_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:luxnewyork_flutter_app/screens/cart_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/wishlist_screen.dart';
+import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   final Product product;
@@ -15,7 +16,7 @@ class ProductDetailScreen extends StatelessWidget {
   const ProductDetailScreen({super.key, required this.product});
 
   void _showSnackbar(BuildContext context, String message, {VoidCallback? onView}) {
-    ScaffoldMessenger.of(context).showSnackBar(
+    showAppSnackBar(
       SnackBar(
         content: Text(message),
         duration: const Duration(seconds: 2),


### PR DESCRIPTION
## Summary
- replace `ScaffoldMessenger.of(context).showSnackBar` calls with `showAppSnackBar`
- import `snackbar_service.dart` in affected screens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bf3d8fd08332a2ee4f2a871eefed