### PR TITLE
Fix removal persistence

### DIFF
--- a/lib/providers/cart_provider.dart
+++ b/lib/providers/cart_provider.dart
@@ -93,20 +93,22 @@ class CartProvider extends ChangeNotifier {
 
     final itemId = _cartItemIds[productId];
 
-    if (itemId != null) {
-      final response = await http.delete(
-        Uri.parse('$apiBaseUrl/api/cart/$itemId'),
-        headers: {'Authorization': 'Bearer $token'},
-      );
-
-      if (response.statusCode != 200 && response.statusCode != 204) {
-        throw Exception('Failed to remove from cart');
-      }
+    if (itemId == null) {
+      throw Exception('Failed to remove from cart');
     }
 
-    _items.removeWhere((item) => item.id == productId);
-    _cartItemIds.remove(productId);
-    notifyListeners();
+    final response = await http.delete(
+      Uri.parse('$apiBaseUrl/api/cart/$itemId'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 204) {
+      _items.removeWhere((item) => item.id == productId);
+      _cartItemIds.remove(productId);
+      notifyListeners();
+    } else {
+      throw Exception('Failed to remove from cart');
+    }
   }
 
   int get itemCount => _items.length;

--- a/lib/providers/wishlist_provider.dart
+++ b/lib/providers/wishlist_provider.dart
@@ -57,17 +57,20 @@ class WishlistProvider extends ChangeNotifier {
 
     if (index >= 0) {
       final itemId = _wishlistItemIds[product.id];
-      if (itemId != null) {
-        final response = await http.delete(
-          Uri.parse('$apiBaseUrl/api/wishlist/$itemId'),
-          headers: {'Authorization': 'Bearer $token'},
-        );
-        if (response.statusCode == 200 || response.statusCode == 204) {
-          _wishlist.removeAt(index);
-          _wishlistItemIds.remove(product.id);
-        } else {
-          throw Exception('Failed to remove from wishlist');
-        }
+      if (itemId == null) {
+        throw Exception('Failed to remove from wishlist');
+      }
+
+      final response = await http.delete(
+        Uri.parse('$apiBaseUrl/api/wishlist/$itemId'),
+        headers: {'Authorization': 'Bearer $token'},
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 204) {
+        _wishlist.removeAt(index);
+        _wishlistItemIds.remove(product.id);
+      } else {
+        throw Exception('Failed to remove from wishlist');
       }
     } else {
       final response = await http.post(


### PR DESCRIPTION
## Summary
- ensure cart removal only occurs when API call succeeds
- throw if cart item id is missing
- do similar for wishlist toggling

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c26fe68c8332b9021aee3fbc142f