### PR TITLE
Fix snackbar after empty-state navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,6 +58,7 @@ import 'providers/theme_provider.dart';
 import 'providers/product_provider.dart';
 import 'providers/connectivity_provider.dart';
 import 'providers/order_provider.dart';
+import 'providers/navigation_provider.dart';
 
 import 'services/store_proximity_service.dart';
 
@@ -77,6 +78,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => ProductProvider()),
         ChangeNotifierProvider(create: (_) => ConnectivityProvider()),
         ChangeNotifierProvider(create: (_) => OrderProvider()),
+        ChangeNotifierProvider(create: (_) => NavigationProvider()),
       ],
       child: const MyApp(),
     ),

--- a/lib/providers/navigation_provider.dart
+++ b/lib/providers/navigation_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class NavigationProvider extends ChangeNotifier {
+  int _index = 0;
+
+  int get index => _index;
+
+  void setIndex(int index) {
+    if (_index != index) {
+      _index = index;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -9,8 +9,8 @@ import '../widgets/skeleton.dart';
 import '../widgets/connection_error_widget.dart';
 import '../providers/connectivity_provider.dart';
 import '../widgets/empty_state_widget.dart';
-import 'main_screen.dart';
 import 'checkout_screen.dart';
+import 'package:luxnewyork_flutter_app/providers/navigation_provider.dart';
 import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
 
 class CartScreen extends StatefulWidget {
@@ -116,10 +116,7 @@ class _CartScreenState extends State<CartScreen> {
               message: 'Your cart is empty.',
               actionText: 'Shop Now',
               onAction: () {
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (_) => const MainScreen()),
-                );
+                context.read<NavigationProvider>().setIndex(0);
               },
               icon: Icons.shopping_bag_outlined,
             ),

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -11,6 +11,7 @@ import 'package:luxnewyork_flutter_app/screens/my_orders_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:luxnewyork_flutter_app/providers/cart_provider.dart';
 import 'package:luxnewyork_flutter_app/providers/theme_provider.dart';
+import 'package:luxnewyork_flutter_app/providers/navigation_provider.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:battery_plus/battery_plus.dart';
 import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
@@ -23,7 +24,6 @@ class MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<MainScreen> {
-  int _selectedIndex = 0;
   late StreamSubscription<List<ConnectivityResult>> _connectivitySub;
   bool _isOffline = false;
   final Battery _battery = Battery();
@@ -36,9 +36,7 @@ class _MainScreenState extends State<MainScreen> {
   ];
 
   void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
+    context.read<NavigationProvider>().setIndex(index);
   }
 
   Future<void> _checkBattery() async {
@@ -114,13 +112,13 @@ class _MainScreenState extends State<MainScreen> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
+    final selectedIndex = context.watch<NavigationProvider>().index;
+
     return PopScope(
-      canPop: _selectedIndex == 0,
+      canPop: selectedIndex == 0,
       onPopInvoked: (didPop) {
-        if (!didPop && _selectedIndex != 0) {
-          setState(() {
-            _selectedIndex = 0;
-          });
+        if (!didPop && selectedIndex != 0) {
+          context.read<NavigationProvider>().setIndex(0);
         }
       },
       child: Scaffold(
@@ -142,14 +140,14 @@ class _MainScreenState extends State<MainScreen> {
           ],
         ),
         body: IndexedStack(
-          index: _selectedIndex,
+          index: selectedIndex,
           children: _screens,
         ),
         bottomNavigationBar: BottomNavigationBar(
           backgroundColor: colorScheme.surface,
           selectedItemColor: colorScheme.primary,
           unselectedItemColor: colorScheme.onSurfaceVariant,
-          currentIndex: _selectedIndex,
+          currentIndex: selectedIndex,
           onTap: _onItemTapped,
           items: [
             const BottomNavigationBarItem(

--- a/lib/screens/my_orders_screen.dart
+++ b/lib/screens/my_orders_screen.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import '../providers/order_provider.dart';
 import '../widgets/list_tile_skeleton.dart';
 import '../widgets/empty_state_widget.dart';
-import 'main_screen.dart';
+import 'package:luxnewyork_flutter_app/providers/navigation_provider.dart';
 
 class MyOrdersScreen extends StatefulWidget {
   const MyOrdersScreen({super.key});
@@ -95,10 +95,7 @@ class _MyOrdersScreenState extends State<MyOrdersScreen> {
                     message: 'No orders found.',
                     actionText: 'Shop Now',
                     onAction: () {
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(builder: (_) => const MainScreen()),
-                      );
+                      context.read<NavigationProvider>().setIndex(0);
                     },
                     icon: Icons.receipt_long,
                   ),

--- a/lib/screens/wishlist_screen.dart
+++ b/lib/screens/wishlist_screen.dart
@@ -7,7 +7,7 @@ import 'package:luxnewyork_flutter_app/widgets/product_card_skeleton.dart';
 import 'package:luxnewyork_flutter_app/widgets/connection_error_widget.dart';
 import 'package:luxnewyork_flutter_app/providers/connectivity_provider.dart';
 import 'package:luxnewyork_flutter_app/widgets/empty_state_widget.dart';
-import 'main_screen.dart';
+import 'package:luxnewyork_flutter_app/providers/navigation_provider.dart';
 
 class WishlistScreen extends StatefulWidget {
   const WishlistScreen({super.key});
@@ -117,10 +117,7 @@ class _WishlistScreenState extends State<WishlistScreen> {
               message: 'Your wishlist is empty.',
               actionText: 'Browse Products',
               onAction: () {
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (_) => const MainScreen()),
-                );
+                context.read<NavigationProvider>().setIndex(0);
               },
               icon: Icons.favorite_border,
             ),


### PR DESCRIPTION
## Summary
- add `NavigationProvider` to manage bottom navigation index
- use `NavigationProvider` from MainScreen
- open home tab via provider in empty state actions