### PR TITLE
Add email validation utility

### DIFF
--- a/lib/screens/forgot_password_screen.dart
+++ b/lib/screens/forgot_password_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
+import 'package:luxnewyork_flutter_app/utils/validators.dart';
 import 'login_screen.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
@@ -85,9 +86,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           keyboardType: TextInputType.emailAddress,
           validator: (value) {
             if (value!.isEmpty) return "Please enter your email";
-            final emailRegex =
-                RegExp(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$");
-            return emailRegex.hasMatch(value) ? null : "Enter a valid email";
+            return isValidEmail(value) ? null : "Enter a valid email";
           },
         ),
         const SizedBox(height: 20),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:luxnewyork_flutter_app/screens/signup_screen.dart';
 import 'package:luxnewyork_flutter_app/screens/forgot_password_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
+import 'package:luxnewyork_flutter_app/utils/validators.dart';
 import '../config.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -166,9 +167,7 @@ class _LoginScreenState extends State<LoginScreen> {
             if (value == null || value.isEmpty) {
               return "Please enter your email";
             }
-            final emailRegex =
-                RegExp(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$");
-            if (!emailRegex.hasMatch(value)) return "Enter a valid email";
+            if (!isValidEmail(value)) return "Enter a valid email";
             return null;
           },
         ),

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:luxnewyork_flutter_app/screens/main_screen.dart';
 import 'package:luxnewyork_flutter_app/widgets/skeleton.dart';
 import 'package:luxnewyork_flutter_app/utils/snackbar_service.dart';
+import 'package:luxnewyork_flutter_app/utils/validators.dart';
 import '../config.dart';
 
 class SignupScreen extends StatefulWidget {
@@ -185,10 +186,7 @@ class _SignupScreenState extends State<SignupScreen> {
             if (value == null || value.isEmpty) {
               return "Please enter your email";
             }
-            // email validation //ANCHOR - Use of email validation
-            final emailRegex =
-                RegExp(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$");
-            if (!emailRegex.hasMatch(value)) {
+            if (!isValidEmail(value)) {
               return "Enter a valid email";
             }
             return null;

--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -1,0 +1,4 @@
+bool isValidEmail(String email) {
+  final emailRegex = RegExp(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$");
+  return emailRegex.hasMatch(email);
+}


### PR DESCRIPTION
## Summary
- add `validators.dart` with `isValidEmail`
- import and use `isValidEmail` in login, signup and forgot password screens